### PR TITLE
WIP: Make dependencies installable via pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,11 @@ setup_params = dict(
     author_email=__email__,
     maintainer=__author__,
     maintainer_email=__email__,
+    install_requires=[
+        "SQLAlchemy",
+        "pyrqlite",
+    ],
+    dependency_links=['https://github.com/rqlite/pyrqlite/tarball/master#egg=pyrqlite-2'],
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Environment :: Console',

--- a/src/sqlalchemy_rqlite/__init__.py
+++ b/src/sqlalchemy_rqlite/__init__.py
@@ -1,11 +1,14 @@
+try:
+    from sqlalchemy.dialects.sqlite import base, pysqlite, pysqlcipher
 
-from sqlalchemy.dialects.sqlite import base, pysqlite, pysqlcipher
+    from sqlalchemy.dialects.sqlite.base import (
+        BLOB, BOOLEAN, CHAR, DATE, DATETIME, DECIMAL, FLOAT, INTEGER, REAL,
+        NUMERIC, SMALLINT, TEXT, TIME, TIMESTAMP, VARCHAR, dialect,
+    )
 
-from sqlalchemy.dialects.sqlite.base import (
-    BLOB, BOOLEAN, CHAR, DATE, DATETIME, DECIMAL, FLOAT, INTEGER, REAL,
-    NUMERIC, SMALLINT, TEXT, TIME, TIMESTAMP, VARCHAR, dialect,
-)
-
-__all__ = ('BLOB', 'BOOLEAN', 'CHAR', 'DATE', 'DATETIME', 'DECIMAL',
-           'FLOAT', 'INTEGER', 'NUMERIC', 'SMALLINT', 'TEXT', 'TIME',
-           'TIMESTAMP', 'VARCHAR', 'REAL', 'dialect')
+    __all__ = ('BLOB', 'BOOLEAN', 'CHAR', 'DATE', 'DATETIME', 'DECIMAL',
+               'FLOAT', 'INTEGER', 'NUMERIC', 'SMALLINT', 'TEXT', 'TIME',
+               'TIMESTAMP', 'VARCHAR', 'REAL', 'dialect')
+except ImportError:
+    # This happens when pip calls setup.py before sqlalchemy is installed.
+    pass


### PR DESCRIPTION
When I add `git+https://github.com/rqlite/sqlalchemy-rqlite@master#egg=sqlalchemy_rqlite` to the requirements.txt of my app, the installation via pip fails:
```
Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/6z/y38b6t5s03s5x5vqctknwpk80000gn/T/pip-build-h66s1s36/sqlalchemy-rqlite/setup.py", line 13, in <module>
        from sqlalchemy_rqlite.constants import (
      File "src/sqlalchemy_rqlite/__init__.py", line 2, in <module>
        from sqlalchemy.dialects.sqlite import base, pysqlite, pysqlcipher
    ImportError: No module named 'sqlalchemy
```
First I added `install_requires` with `sqlalchemy` and `pyrqlite` to the `setup.py`.

But when `setup.py` is processed by pip it tries to import stuff from `sqlalchemy_rqlite`, which leads to the execution of `sqlalchemy_rqlite/__init__.py`, which itself imports `sqlalchemy` stuff, which is not installed yet.

To make this work, I basically removed the import of `sqlalchemy_rqlite.constants` from the `setup.py` and adapted it accordingly. 

Now i can install my app with the following line in the requirements.txt
```
...
git+https://github.com/kaihil/sqlalchemy-rqlite@install_requires#egg=sqlalchemy_rqlite
```
via
```
pip install --process-dependency-links -r requirements.txt
```

It would be great to be able to install the lib from the main repo (or pypi) via pip.