### PR TITLE
Fix failing url query dict copy with sqlalchemy 1.4

### DIFF
--- a/src/sqlalchemy_rqlite/pyrqlite.py
+++ b/src/sqlalchemy_rqlite/pyrqlite.py
@@ -72,7 +72,7 @@ class SQLiteDialect_rqlite(SQLiteDialect):
             return pool.SingletonThreadPool
 
     def create_connect_args(self, url):
-        opts = url.query.copy()
+        opts = dict(url.query)
         util.coerce_kw_type(opts, 'connect_timeout', float)
         util.coerce_kw_type(opts, 'detect_types', int)
         util.coerce_kw_type(opts, 'max_redirects', int)


### PR DESCRIPTION
Currently using `sqlalchemy-rqlite` with SQLAlchemy version 1.4 or later will fail with the following error:

```
AttributeError: 'sqlalchemy.cimmutabledict.immutabledict' object has no attribute 'copy'
```

As per the documentation at https://docs.sqlalchemy.org/en/14/core/engines.html#sqlalchemy.engine.URL.query the appropriate way to create a mutable copy of the query dict  is now to use the `dict` constructor.