### PR TITLE
Rename dbapi method to import_dbapi

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,8 @@
 
 
+## 2.0 (May 11 2023)
+- [PR #22](https://github.com/rqlite/sqlalchemy-rqlite/pull/22): Rename dbapi method to import_dbapi.
+
 ## 1.2 (May 11 2023)
 - [PR #17](https://github.com/rqlite/sqlalchemy-rqlite/pull/17): Make compatible with SQLAlchemy 2.0.
 - [PR #12](https://github.com/rqlite/sqlalchemy-rqlite/pull/12): Add do_ping for sqlalchemy_rqlite dialect.

--- a/src/sqlalchemy_rqlite/pyrqlite.py
+++ b/src/sqlalchemy_rqlite/pyrqlite.py
@@ -54,7 +54,7 @@ class SQLiteDialect_rqlite(SQLiteDialect):
 
     # pylint: disable=method-hidden
     @classmethod
-    def dbapi(cls):
+    def import_dbapi(cls):
         try:
             # pylint: disable=no-name-in-module
             from pyrqlite import dbapi2 as sqlite
@@ -63,6 +63,9 @@ class SQLiteDialect_rqlite(SQLiteDialect):
             #raise e
             raise
         return sqlite
+
+    # SQLAlchemy 1.x compatibility.
+    dbapi = import_dbapi
 
     @classmethod
     def get_pool_class(cls, url):


### PR DESCRIPTION
In SQLAlchemy 2.0, the dbapi method was renamed to import_dbapi, so rename it to import_dbapi and add a dbapi alias for SQLAlchemy 1.x compatibility.

Closes: https://github.com/rqlite/sqlalchemy-rqlite/issues/21