### PR TITLE
Add _get_server_version_info method

### DIFF
--- a/src/sqlalchemy_rqlite/pyrqlite.py
+++ b/src/sqlalchemy_rqlite/pyrqlite.py
@@ -105,4 +105,7 @@ class SQLiteDialect_rqlite(SQLiteDialect):
         else:
             return True
 
+    def _get_server_version_info(self, connection):
+        return self.dbapi.sqlite_version_info
+
 dialect = SQLiteDialect_rqlite


### PR DESCRIPTION
This PR adds a `_get_server_version_info` to SQLiteDialect_rqlite same as in the pysqlite one

https://github.com/sqlalchemy/sqlalchemy/blob/65c20833d4531c23acba05d30d1e28f463810354/lib/sqlalchemy/dialects/sqlite/pysqlite.py#L475
